### PR TITLE
Use timestamps as header

### DIFF
--- a/include/CUDPClient.hpp
+++ b/include/CUDPClient.hpp
@@ -20,6 +20,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <spdlog/spdlog.h>
+#include <queue>
 
 class CUDPClient {
 private:

--- a/include/CUDPClient.hpp
+++ b/include/CUDPClient.hpp
@@ -35,6 +35,7 @@ private:
     ssize_t _tx_code = 0;
     struct sockaddr_in _server_addr{};
     socklen_t _server_addr_len = 0;
+    int _response_time_ms = 0;
 
 public:
     CUDPClient();
@@ -46,4 +47,5 @@ public:
     bool ping();
 
     bool get_socket_status();
+    int get_last_response_time();
 };

--- a/include/CUDPClient.hpp
+++ b/include/CUDPClient.hpp
@@ -32,6 +32,7 @@ private:
     ssize_t _bytes_moved = 0;
     struct sockaddr_in _server_addr{};
     socklen_t _server_addr_len = 0;
+
 public:
     CUDPClient();
     ~CUDPClient();

--- a/include/CUDPClient.hpp
+++ b/include/CUDPClient.hpp
@@ -30,6 +30,8 @@ private:
     int _socket_fd = 0;
     bool _socket_ok = false;
     ssize_t _bytes_moved = 0;
+    ssize_t _rx_code = 0;
+    ssize_t _tx_code = 0;
     struct sockaddr_in _server_addr{};
     socklen_t _server_addr_len = 0;
 

--- a/include/CUDPServer.hpp
+++ b/include/CUDPServer.hpp
@@ -30,6 +30,7 @@ private:
     struct sockaddr_in _client_addr{};
     socklen_t _client_addr_len = 0;
     std::vector<uint8_t> _recv_buffer;
+
 public:
     CUDPServer();
     ~CUDPServer();

--- a/include/CUDPServer.hpp
+++ b/include/CUDPServer.hpp
@@ -25,7 +25,7 @@ private:
 
     int _port = 0;
     int _socket_fd = 0;
-    ssize_t _read_code = 0;
+    ssize_t _rx_code = 0;
     struct sockaddr_in _server_addr{};
     struct sockaddr_in _client_addr{};
     socklen_t _client_addr_len = 0;

--- a/include/CUDPServer.hpp
+++ b/include/CUDPServer.hpp
@@ -18,6 +18,7 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <spdlog/spdlog.h>
+#include <queue>
 
 class CUDPServer {
 private:
@@ -26,6 +27,7 @@ private:
     int _port = 0;
     int _socket_fd = 0;
     ssize_t _rx_code = 0;
+    std::queue<std::string> _rx_time_queue;
     struct sockaddr_in _server_addr{};
     struct sockaddr_in _client_addr{};
     socklen_t _client_addr_len = 0;

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -99,12 +99,17 @@ bool CUDPClient::ping() {
         }
     }
 
-    auto data_begin = std::find(buffer.begin(), buffer.end(), '|');
-    if (data_begin++ == buffer.end()) {
-        spdlog::error("Cannot find separator");
-        return false;
-    }
-    return (*(data_begin) == '\6');
+    // turn rx into ss
+    std::stringstream rx_raw(std::string(buffer.begin(),buffer.begin() + _bytes_moved));
+
+    // split ss into time and data
+    std::string time, data;
+    rx_raw >> time;
+    spdlog::info("[" + time + "]");
+    rx_raw >> data;
+    spdlog::info("[" + data + "]");
+
+    return (data == "\6");
 }
 
 bool CUDPClient::do_rx(std::vector<uint8_t> &rx_buf, long &rx_bytes) {

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -72,10 +72,9 @@ void CUDPClient::setdn() const {
 }
 
 bool CUDPClient::ping() {
-    std::string ping_string = "C|\5";
-    std::vector<uint8_t> buffer(ping_string.begin(), ping_string.end());
+    std::string buffer = "C|\5";
 
-    if (!(sendto(_socket_fd, buffer.data(), buffer.capacity(), 0,
+    if (!(sendto(_socket_fd, buffer.data(), buffer.size(), 0,
                 (struct sockaddr *) &_server_addr, sizeof(_server_addr)))) {
         spdlog::error("General error during ping tx");
         return false;
@@ -85,10 +84,11 @@ bool CUDPClient::ping() {
     _bytes_moved = 0;
 
     auto ping_timeout_start = std::chrono::steady_clock::now();
+    buffer.clear();
 
     // spins until ping response or timeout
     while (_bytes_moved <= 0) {
-        _bytes_moved = recvfrom(_socket_fd, buffer.data(), buffer.capacity(), 0,
+        _bytes_moved = recvfrom(_socket_fd, buffer.data(), buffer.size(), 0,
                                 (struct sockaddr *) &_server_addr, &_server_addr_len);
         if ((int) std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - ping_timeout_start).count() > PING_TIMEOUT) {
@@ -96,7 +96,6 @@ bool CUDPClient::ping() {
             return false;
         }
     }
-
     return (buffer.at(2) == '\6');
 }
 

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -105,9 +105,7 @@ bool CUDPClient::ping() {
     // split ss into time and data
     std::string time, data;
     rx_raw >> time;
-    spdlog::info("[" + time + "]");
     rx_raw >> data;
-    spdlog::info("[" + data + "]");
 
     return (data == "\6");
 }
@@ -138,13 +136,11 @@ bool CUDPClient::do_rx(std::vector<uint8_t> &rx_buf, long &rx_bytes) {
     // split ss into time and data
     std::string time, data;
     rx_raw_ss >> time;
-    spdlog::info("[" + time + "]" + " DELAY: " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - std::stol(time)));
     rx_raw_ss >> data;
     if (data.empty()) {
         spdlog::error("Malformed data received");
         return false;
     }
-    spdlog::info("[" + data + "]");
 
     rx_buf = std::vector<uint8_t>(data.begin(), data.end());
     rx_bytes = (long) data.length();
@@ -165,8 +161,6 @@ bool CUDPClient::do_tx(const std::vector<uint8_t> &tx_buf) {
     // send message to server
     _tx_code = sendto(_socket_fd, tx_this.data(), tx_this.size(), 0,
                           (struct sockaddr *) &_server_addr, _server_addr_len);
-
-    spdlog::info("[" + std::string(tx_this.begin(),tx_this.end()) + "]");
 
     // if problem with sending data, return false
     if (_tx_code < 0) {

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -109,16 +109,16 @@ bool CUDPClient::do_rx(std::vector<uint8_t> &rx_buf, long &rx_bytes) {
     _server_addr_len = sizeof(_server_addr);
 
     // reset rx return code
-    _bytes_moved = 0;
+    _rx_code = 0;
 
     // spins until complete response
-    while (_bytes_moved <= 0 && _socket_ok) {
+    while (_rx_code <= 0 && _socket_ok) {
         // send data
-        _bytes_moved = recvfrom(_socket_fd, rx_buf.data(), rx_buf.capacity(), 0,
+        _rx_code = recvfrom(_socket_fd, rx_buf.data(), rx_buf.capacity(), 0,
                                 (struct sockaddr *) &_server_addr, &_server_addr_len);
     }
 
-    rx_bytes = _bytes_moved;
+    rx_bytes = _rx_code;
     return true;
 }
 
@@ -130,11 +130,11 @@ bool CUDPClient::do_tx(const std::vector<uint8_t> &tx_buf) {
     }
 
     // send message to server
-    _bytes_moved = sendto(_socket_fd, tx_buf.data(), tx_buf.size(), 0,
+    _tx_code = sendto(_socket_fd, tx_buf.data(), tx_buf.size(), 0,
                           (struct sockaddr *) &_server_addr, _server_addr_len);
 
     // if problem with sending data, return false
-    if (_bytes_moved < 0) {
+    if (_tx_code < 0) {
         spdlog::error("General error during tx");
         return false;
     }

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -73,7 +73,7 @@ void CUDPClient::setdn() const {
 
 bool CUDPClient::ping() {
     // send prefix and ENQ
-    std::string buffer = "C|\5";
+    std::string buffer = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()) + " \5";
 
     if (!(sendto(_socket_fd, buffer.data(), buffer.size(), 0,
                 (struct sockaddr *) &_server_addr, sizeof(_server_addr)))) {

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -139,7 +139,7 @@ bool CUDPClient::do_rx(std::vector<uint8_t> &rx_buf, long &rx_bytes) {
     rx_raw_ss >> data;
 
     // measure response time
-    _response_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - std::stol(time);
+    _response_time_ms = (int) (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - std::stol(time));
     if (data.empty()) {
         spdlog::error("Malformed data received");
         return false;

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -142,9 +142,15 @@ bool CUDPClient::do_tx(const std::vector<uint8_t> &tx_buf) {
         return false;
     }
 
+    std::string now = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()) + " ";;
+    std::vector<uint8_t> tx_this(now.begin(), now.end());
+    tx_this.insert(tx_this.end(),tx_buf.begin(),tx_buf.end());
+
     // send message to server
-    _tx_code = sendto(_socket_fd, tx_buf.data(), tx_buf.size(), 0,
+    _tx_code = sendto(_socket_fd, tx_this.data(), tx_this.size(), 0,
                           (struct sockaddr *) &_server_addr, _server_addr_len);
+
+    spdlog::info("[" + std::string(tx_this.begin(),tx_this.end()) + "]");
 
     // if problem with sending data, return false
     if (_tx_code < 0) {

--- a/src/CUDPClient.cpp
+++ b/src/CUDPClient.cpp
@@ -137,6 +137,9 @@ bool CUDPClient::do_rx(std::vector<uint8_t> &rx_buf, long &rx_bytes) {
     std::string time, data;
     rx_raw_ss >> time;
     rx_raw_ss >> data;
+
+    // measure response time
+    _response_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - std::stol(time);
     if (data.empty()) {
         spdlog::error("Malformed data received");
         return false;
@@ -172,4 +175,8 @@ bool CUDPClient::do_tx(const std::vector<uint8_t> &tx_buf) {
 
 bool CUDPClient::get_socket_status() {
     return _socket_ok;
+}
+
+int CUDPClient::get_last_response_time() {
+    return _response_time_ms;
 }

--- a/src/CUDPServer.cpp
+++ b/src/CUDPServer.cpp
@@ -57,6 +57,11 @@ bool CUDPServer::do_rx(
         close(_socket_fd);
         return false;
     }
+    if (rx_buf.at(2) == '\5') {
+        // ping packet detected
+        std::string ping_string = "C|\6";
+        do_tx(std::vector<uint8_t>(ping_string.begin(),ping_string.end()),_client_addr);
+    }
     rx_bytes = _read_code;
     src = _client_addr;
     return true;

--- a/src/CUDPServer.cpp
+++ b/src/CUDPServer.cpp
@@ -51,8 +51,8 @@ bool CUDPServer::do_rx(
 
     // listen for client
     _client_addr_len = sizeof(_client_addr);
-    _read_code = recvfrom(_socket_fd, rx_buf.data(), rx_buf.capacity(), 0, (struct sockaddr *) &_client_addr, &_client_addr_len);
-    if (_read_code < 0) {
+    _rx_code = recvfrom(_socket_fd, rx_buf.data(), rx_buf.capacity(), 0, (struct sockaddr *) &_client_addr, &_client_addr_len);
+    if (_rx_code < 0) {
         spdlog::error("Error reading data.");
         close(_socket_fd);
         return false;

--- a/src/CUDPServer.cpp
+++ b/src/CUDPServer.cpp
@@ -65,14 +65,12 @@ bool CUDPServer::do_rx(
     // split ss into time and data
     std::string time, data;
     rx_raw_ss >> time;
-    spdlog::info("[" + time + "]");
     _rx_time_queue.emplace(time);
     rx_raw_ss >> data;
     if (data.empty()) {
         spdlog::error("Malformed data received");
         return false;
     }
-    spdlog::info("[" + data + "]");
 
     // respond if ping
     if (data == "\5") {
@@ -95,8 +93,6 @@ bool CUDPServer::do_tx(const std::vector<uint8_t> &tx_buf,
     _rx_time_queue.pop();
     tx_this.emplace_back(' ');
     tx_this.insert(tx_this.end(),tx_buf.begin(),tx_buf.end());
-    spdlog::info("BUFFER: " + std::string(tx_buf.begin(), tx_buf.end()));
-    spdlog::info("WILL SEND: " + std::string(tx_this.begin(), tx_this.end()));
     // respond to client
     if (sendto(_socket_fd, tx_this.data(), tx_this.size(), 0, (struct sockaddr *) &dst, sizeof(dst)) <
         0) {

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <queue>
+#include <csignal>
 
 #include "../include/CUDPClient.hpp"
 

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -24,7 +24,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
-        spdlog::info("Listening");
+//        spdlog::info("Listening");
         c->do_rx(rx_buf,rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
 //        spdlog::info("Recieved " + std::to_string(rx_bytes) + " bytes");
@@ -36,7 +36,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
 void do_send(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         for (; !q->empty(); q->pop()) {
-            spdlog::info("Sending");
+//            spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());
             c->do_tx(tx_buf);
         }
@@ -92,7 +92,9 @@ int main(int argc, char *argv[]) {
         }
 
         // send current time in milliseconds since epoch
-        tx_queue.emplace(std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
+        auto now = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+        spdlog::info(now);
+        tx_queue.emplace(now);
 
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
     }

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -98,6 +98,7 @@ int main(int argc, char *argv[]) {
         // send current time as payload
 //        tx_queue.emplace(std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
         tx_queue.emplace("asdf");
+        spdlog::info("Last response time (ms): " + std::to_string(c.get_last_response_time()));
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -30,7 +30,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
         rx_buf.clear();
         spdlog::info("Listening");
         c->do_rx(rx_buf,rx_bytes);
-        std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);\
+        std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
         // only add to rx queue if data is not empty
         if(!temp.empty()) q->emplace(temp);
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
@@ -96,7 +96,8 @@ int main(int argc, char *argv[]) {
         }
 
         // send current time as payload
-        tx_queue.emplace(std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
+//        tx_queue.emplace(std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
+        tx_queue.emplace("asdf");
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -9,6 +9,9 @@
 
 #include "../include/CUDPClient.hpp"
 
+#define PING_TIMEOUT 1000
+#define NET_DELAY 10
+
 volatile sig_atomic_t stop;
 volatile bool send_data = true;
 volatile bool stop_main = false;
@@ -24,23 +27,23 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
-//        spdlog::info("Listening");
+        spdlog::info("Listening");
         c->do_rx(rx_buf,rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
 //        spdlog::info("Recieved " + std::to_string(rx_bytes) + " bytes");
         q->emplace(temp);
-        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
+        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 }
 
 void do_send(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         for (; !q->empty(); q->pop()) {
-//            spdlog::info("Sending");
+            spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());
             c->do_tx(tx_buf);
         }
-        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
+        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 }
 
@@ -67,12 +70,15 @@ int main(int argc, char *argv[]) {
     std::thread thread_for_sending(do_send, &c, &tx_queue);
     thread_for_sending.detach();
 
+    // tell server to start streaming data
+    tx_queue.emplace("G 0");
+
     while(!stop_main) {
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
             // acknowledge next data in queue
-//            spdlog::info("New in RX queue: " + rx_queue.front());
-//            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
+            spdlog::info("New in RX queue: " + rx_queue.front());
+            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
             // reset timeout
             // placement of this may be a source of future bug
@@ -80,7 +86,7 @@ int main(int argc, char *argv[]) {
         }
 
         time_since_start = (int) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeout_count).count();
-        if (time_since_start > 1000) {
+        if (time_since_start > PING_TIMEOUT) {
             spdlog::warn("Server is gone...");
             send_data = false;
             do {
@@ -89,17 +95,18 @@ int main(int argc, char *argv[]) {
             } while (!c.get_socket_status());
             send_data = c.get_socket_status();
             timeout_count = std::chrono::steady_clock::now();
+            tx_queue.emplace("G 0");
         }
 
-        // send current time in milliseconds since epoch
-        auto now = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
-        spdlog::info(now);
-        tx_queue.emplace(now);
-
-        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
+        // send alive ping
+        tx_queue.emplace("A 0");
+        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
+        tx_queue.emplace("S 1 103 204 4444 24 8");
+        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 
     spdlog::info("Stopping nicely");
+    tx_queue.emplace("S 0");
 
     // wait for send stop...
     std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(100));

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -71,8 +71,8 @@ int main(int argc, char *argv[]) {
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
             // acknowledge next data in queue
-            spdlog::info("New in RX queue: " + rx_queue.front());
-            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
+//            spdlog::info("New in RX queue: " + rx_queue.front());
+//            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
             // reset timeout
             // placement of this may be a source of future bug

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -33,7 +33,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
         // only add to rx queue if data is not empty
         if(!temp.empty()) q->emplace(temp);
-        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
+        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(1));
     }
 }
 

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -30,9 +30,9 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
         rx_buf.clear();
         spdlog::info("Listening");
         c->do_rx(rx_buf,rx_bytes);
-        std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
-//        spdlog::info("Recieved " + std::to_string(rx_bytes) + " bytes");
-        q->emplace(temp);
+        std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);\
+        // only add to rx queue if data is not empty
+        if(!temp.empty()) q->emplace(temp);
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 }
@@ -71,9 +71,6 @@ int main(int argc, char *argv[]) {
     std::thread thread_for_sending(do_send, &c, &tx_queue);
     thread_for_sending.detach();
 
-    // tell server to start streaming data
-    tx_queue.emplace("G 0");
-
     while(!stop_main) {
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
@@ -96,18 +93,16 @@ int main(int argc, char *argv[]) {
             } while (!c.get_socket_status());
             send_data = c.get_socket_status();
             timeout_count = std::chrono::steady_clock::now();
-            tx_queue.emplace("G 0");
         }
 
-        // send alive ping
-        tx_queue.emplace("A 0");
-        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
-        tx_queue.emplace("S 1 103 204 4444 24 8");
+        // send current time as payload
+        tx_queue.emplace(std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 
+    // tx EOT to stop
     spdlog::info("Stopping nicely");
-    tx_queue.emplace("S 0");
+    tx_queue.emplace("\4");
 
     // wait for send stop...
     std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(100));

--- a/test/TestClient.cpp
+++ b/test/TestClient.cpp
@@ -28,7 +28,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
-        spdlog::info("Listening");
+//        spdlog::info("Listening");
         c->do_rx(rx_buf,rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
         // only add to rx queue if data is not empty
@@ -40,7 +40,7 @@ void do_listen(CUDPClient *c, std::queue<std::string> *q) {
 void do_send(CUDPClient *c, std::queue<std::string> *q) {
     while (stop != 1) {
         for (; !q->empty(); q->pop()) {
-            spdlog::info("Sending");
+//            spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());
             c->do_tx(tx_buf);
         }
@@ -74,9 +74,9 @@ int main(int argc, char *argv[]) {
     while(!stop_main) {
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
-            // acknowledge next data in queue
-            spdlog::info("New in RX queue: " + rx_queue.front());
-            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
+//            // acknowledge next data in queue
+//            spdlog::info("New in RX queue: " + rx_queue.front());
+//            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
             // reset timeout
             // placement of this may be a source of future bug

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -35,7 +35,6 @@ void do_listen(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *src) {
 }
 
 void do_send(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *dst) {
-    int number = 0;
     while (stop != 1) {
         if (send_data) q->emplace("sample text");
         for (; !q->empty(); q->pop()) {

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -71,8 +71,8 @@ int main() {
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
             // acknowledge next data in queue
-            spdlog::info("New in RX queue: " + rx_queue.front());
-            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
+//            spdlog::info("New in RX queue: " + rx_queue.front());
+//            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
             // Return data received from client
             tx_queue.emplace(rx_queue.front());

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -38,7 +38,7 @@ void do_send(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *dst) {
     while (stop != 1) {
         if (send_data) q->emplace("sample text");
         for (; !q->empty(); q->pop()) {
-            spdlog::info("Sending");
+//            spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());
             s->do_tx(tx_buf,*dst);
         }

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -71,9 +71,9 @@ int main() {
          */
         for (; !rx_queue.empty(); rx_queue.pop()) {
 
-            // acknowledge next data in queue
-            spdlog::info("New in RX queue: " + rx_queue.front());
-            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
+//            // acknowledge next data in queue
+//            spdlog::info("New in RX queue: " + rx_queue.front());
+//            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
             // echo client data back to client
             tx_queue.emplace(rx_queue.front());

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -38,7 +38,7 @@ void do_listen(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *src) {
 void do_send(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *dst) {
     int number = 0;
     while (stop != 1) {
-        if (send_data) q->emplace(std::to_string(number++));
+        if (send_data) q->emplace("sample text");
         for (; !q->empty(); q->pop()) {
             spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -25,11 +25,9 @@ void do_listen(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *src) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
-//        spdlog::info("Listening");
         s->do_rx(rx_buf, *src, rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
-//        spdlog::info("Recieved " + std::to_string(rx_bytes) + " bytes");
-        q->emplace(temp);
+        if (!temp.empty()) q->emplace(temp);
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
     }
 }

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -25,6 +25,7 @@ void do_listen(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *src) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
+//        spdlog::info("Listening");
         s->do_rx(rx_buf, *src, rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
         if (!temp.empty()) q->emplace(temp);
@@ -37,7 +38,7 @@ void do_send(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *dst) {
     while (stop != 1) {
         if (send_data) q->emplace(std::to_string(number++));
         for (; !q->empty(); q->pop()) {
-            spdlog::info("Sending");
+//            spdlog::info("Sending");
             std::vector<uint8_t> tx_buf(q->front().begin(),q->front().end());
             s->do_tx(tx_buf,*dst);
         }
@@ -73,7 +74,7 @@ int main() {
             // acknowledge next data in queue
 //            spdlog::info("New in RX queue: " + rx_queue.front());
 //            spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
-
+            spdlog::info(rx_queue.front());
             // Return data received from client
             tx_queue.emplace(rx_queue.front());
 

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -26,11 +26,10 @@ void do_listen(CUDPServer *s, std::queue<std::string> *q, sockaddr_in *src) {
     while (stop != 1) {
         rx_bytes = 0;
         rx_buf.clear();
-//        spdlog::info("Listening");
         s->do_rx(rx_buf, *src, rx_bytes);
         std::string temp = std::string(rx_buf.begin(),rx_buf.begin() + rx_bytes);
-//        spdlog::info("Recieved " + std::to_string(rx_bytes) + " bytes");
-        q->emplace(temp);
+        // only add to rx queue if data is not empty
+        if(!temp.empty()) q->emplace(temp);
         std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(NET_DELAY));
     }
 }

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -76,56 +76,59 @@ int main() {
             spdlog::info("New in RX queue: " + rx_queue.front());
             spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
-            // respond to ping
-            if(rx_queue.front()[0] == '\5') {
-                tx_queue.emplace("\6");
-                // it's just a ping packet, move on
-                continue;
-            }
+            // Return data received from client
+            tx_queue.emplace(rx_queue.front());
 
-            std::string action = rx_queue.front().substr(0,3);
-
-            // respond to i'm alive command
-            if(action == "A 0") {
-                timeout_count = std::chrono::steady_clock::now();
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "S 1") {
+//            // respond to ping
+//            if(rx_queue.front()[0] == '\5') {
+//                tx_queue.emplace("\6");
+//                // it's just a ping packet, move on
+//                continue;
+//            }
+//
+//            std::string action = rx_queue.front().substr(0,3);
+//
+//            // respond to i'm alive command
+//            if(action == "A 0") {
+//                timeout_count = std::chrono::steady_clock::now();
+//                continue;
+//            }
+//
+//            // respond to begin get data command
+//            if(action == "S 1") {
+////                send_data = false;
+////                std::stringstream ss;
+////                std::string temp;
+////                ss.str(rx_queue.front());
+////                while(ss >> temp) {
+////                    spdlog::info(temp);
+////                }
+//                spdlog::info(rx_queue.front());
+//                continue;
+//            }
+//
+//            // respond to begin get data command
+//            if(action == "S 0") {
 //                send_data = false;
-//                std::stringstream ss;
-//                std::string temp;
-//                ss.str(rx_queue.front());
-//                while(ss >> temp) {
-//                    spdlog::info(temp);
-//                }
-                spdlog::info(rx_queue.front());
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "S 0") {
-                send_data = false;
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "G 0") {
-                send_data = true;
-                timeout_count = std::chrono::steady_clock::now();
-                continue;
-            }
+//                continue;
+//            }
+//
+//            // respond to begin get data command
+//            if(action == "G 0") {
+//                send_data = true;
+//                timeout_count = std::chrono::steady_clock::now();
+//                continue;
+//            }
         }
 
-        time_since_start = (int) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeout_count).count();
-        if (send_data) {
-//            spdlog::info("Time since last client data: " + std::to_string(time_since_start));
-            if (time_since_start > PING_TIMEOUT) {
-                spdlog::warn("Client is gone...");
-                send_data = false;
-            }
-        }
+//        time_since_start = (int) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeout_count).count();
+//        if (send_data) {
+////            spdlog::info("Time since last client data: " + std::to_string(time_since_start));
+//            if (time_since_start > PING_TIMEOUT) {
+//                spdlog::warn("Client is gone...");
+//                send_data = false;
+//            }
+//        }
 //        std::this_thread::sleep_until(std::chrono::system_clock::now() + std::chrono::milliseconds(10));
     }
 

--- a/test/TestServer.cpp
+++ b/test/TestServer.cpp
@@ -76,46 +76,8 @@ int main() {
             spdlog::info("New in RX queue: " + rx_queue.front());
             spdlog::info("Remaining in queue: " + std::to_string(rx_queue.size()));
 
-            // respond to ping
-            if(rx_queue.front()[0] == '\5') {
-                tx_queue.emplace("\6");
-                // it's just a ping packet, move on
-                continue;
-            }
-
-            std::string action = rx_queue.front().substr(0,3);
-
-            // respond to i'm alive command
-            if(action == "A 0") {
-                timeout_count = std::chrono::steady_clock::now();
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "S 1") {
-//                send_data = false;
-//                std::stringstream ss;
-//                std::string temp;
-//                ss.str(rx_queue.front());
-//                while(ss >> temp) {
-//                    spdlog::info(temp);
-//                }
-                spdlog::info(rx_queue.front());
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "S 0") {
-                send_data = false;
-                continue;
-            }
-
-            // respond to begin get data command
-            if(action == "G 0") {
-                send_data = true;
-                timeout_count = std::chrono::steady_clock::now();
-                continue;
-            }
+            // echo client data back to client
+            tx_queue.emplace(rx_queue.front());
         }
 
         time_since_start = (int) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - timeout_count).count();


### PR DESCRIPTION
Using timestamps as the header allows us to measure the response time.